### PR TITLE
Replace zle reset-prompt with zle -R

### DIFF
--- a/chorn-prompt.zsh
+++ b/chorn-prompt.zsh
@@ -195,7 +195,7 @@ _async_prompt_gitconfigs() {
 }
 #-----------------------------------------------------------------------------
 _async_prompt_callback() {
-  [[ -n "$3" ]] && eval "$3" && zle && zle reset-prompt >&/dev/null
+  [[ -n "$3" ]] && eval "$3" && zle && zle -R >&/dev/null
 }
 #-----------------------------------------------------------------------------
 _chorn_prompt_precmd() {


### PR DESCRIPTION
Because `reset-prompt` seems to have really weird behavior, and in my
environment if I _don't_ use "zsh-autosuggestions" the async updates
lose their minds and it's unusable.